### PR TITLE
use https instead of ssh for llvm submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,5 +16,5 @@
         branch = pnacl/2.34/master
 [submodule "src/llvm"]
 	path = src/llvm
-	url = git@github.com:DiamondLovesYou/llvm.git
+	url = https://github.com/DiamondLovesYou/llvm.git
         branch = merge_36


### PR DESCRIPTION
You can only checkout a Github repository using ssh if you have (write) access to the repository, however anybody can checkout using https.
